### PR TITLE
Actually link to the docs page

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 
 <p>Over the years a lot of tooling on top of Puppet has been developed. Some of those, though in active use, have fallen into a state of decay because the maintainer is AWOL or simply doesn't have the time or need to maintain this tool. The consequence of this is that a forest of forks with different patches and features have arisen and no one knows which one to pick, nor has an guarantee that the fork they're now using will see further development.</p>
 <h2>
-<a name="docs" class="docs.html" href="#tooling"><span class="octicon octicon-link"></span></a>Docs</h2>
+<a name="docs" class="docs.html" href="/docs.html"><span class="octicon octicon-link"></span></a>Docs</h2>
         </section>
 
         <aside id="sidebar">


### PR DESCRIPTION
I'm not sure why we didn't have this before